### PR TITLE
Fix crash on Fedora, due to curl not initializing SSL.

### DIFF
--- a/sdb.c
+++ b/sdb.c
@@ -71,7 +71,7 @@ int sdb_global_init(void)
 
 	// Initialize Curl
 
-	if (curl_global_init(CURL_GLOBAL_NOTHING) != 0) return SDB_E_CURL_INIT_FAILED;
+	if (curl_global_init(CURL_GLOBAL_ALL) != 0) return SDB_E_CURL_INIT_FAILED;
 
 
 	// Initialize global statistics


### PR DESCRIPTION
libsdb crashes on any usage on Fedora as the SSL library is not initialized, I assume this is because curl uses openssl on other platforms and you manually initialize it with SSL_library_init() in sdb_create_curl(). But on Fedora curl uses NSS, so it never gets initialized.

You can only initialize libcurl once, due to a check in curl_global_init(), so when you call curl_global_init() in sdb_global_init with CURL_GLOBAL_NOTHING, subsequent calls trying to initialize more features (like ssl) via curl_easy_init() don't do anything.

I think the simplest solution is just to initialize everything in sdb_global_init(). This _might_ mean you don't have to call SSL_library_init() (I haven't tested Ubuntu/Debian), because curl should take care of it for you. With this patch, the test binary appears to be working normally on Fedora.
